### PR TITLE
removing memory leak and simplifying the api

### DIFF
--- a/library/src/main/java/com/xwray/fontbinding/Bindings.java
+++ b/library/src/main/java/com/xwray/fontbinding/Bindings.java
@@ -11,6 +11,6 @@ public class Bindings {
 
     @BindingAdapter({"bind:font"})
     public static void setFont(TextView textView, String fontName) {
-        textView.setTypeface(FontCache.getInstance(textView.getContext()).get(fontName));
+        textView.setTypeface(FontCache.get(textView.getContext(), fontName));
     }
 }

--- a/library/src/main/java/com/xwray/fontbinding/FontCache.java
+++ b/library/src/main/java/com/xwray/fontbinding/FontCache.java
@@ -21,26 +21,38 @@ import java.util.Map;
  */
 public class FontCache {
 
-    private static String TAG = "FontCache";
     private static final String FONT_DIR = "fonts";
-    private static Map<String, Typeface> cache = new HashMap<>();
-    private static Map<String, String> fontMapping = new HashMap<>();
-    private static FontCache instance;
-    private Context mContext;
+    private static String TAG = "FontCache";
+    private static Map<String, Typeface> cache;
+    private static Map<String, String> fontMapping;
 
-    public static FontCache getInstance(Context context) {
-        if (instance == null) {
-            instance = new FontCache(context.getApplicationContext());
+    private FontCache() {}
+
+    public static Typeface get(Context context, String fontName) {
+        if (fontMapping == null) {
+            fontMapping = new HashMap<>();
+            setupFontMap(context);
         }
-        return instance;
+        if (cache == null) {
+            cache = new HashMap<>();
+        }
+
+        String fontFilename = fontMapping.get(fontName);
+        if (fontFilename == null) {
+            Log.e(TAG, "Couldn't find font " + fontName + ". Maybe you need to call addFont() first?");
+            return null;
+        }
+
+        if (cache.containsKey(fontFilename)) {
+            return cache.get(fontFilename);
+        } else {
+            Typeface typeface = Typeface.createFromAsset(context.getAssets(), FONT_DIR + "/" + fontFilename);
+            cache.put(fontFilename, typeface);
+            return typeface;
+        }
     }
 
-    public void addFont(String name, String fontFilename) {
-        fontMapping.put(name, fontFilename);
-    }
-
-    private FontCache(Context context) {
-        mContext = context;
+    private static void setupFontMap(Context context) {
         AssetManager am = context.getResources().getAssets();
         String fileList[];
         try {
@@ -57,18 +69,7 @@ public class FontCache {
         }
     }
 
-    public Typeface get(String fontName) {
-        String fontFilename = fontMapping.get(fontName);
-        if (fontFilename == null) {
-            Log.e(TAG, "Couldn't find font " + fontName + ". Maybe you need to call addFont() first?");
-            return null;
-        }
-        if (cache.containsKey(fontFilename)) {
-            return cache.get(fontFilename);
-        } else {
-            Typeface typeface = Typeface.createFromAsset(mContext.getAssets(), FONT_DIR + "/" + fontFilename);
-            cache.put(fontFilename, typeface);
-            return typeface;
-        }
+    public void addFont(String name, String fontFilename) {
+        fontMapping.put(name, fontFilename);
     }
 }


### PR DESCRIPTION
- Holding on to the context is a static manner is a memory leak and we can avoid that altogether.
- Also there is no need for instantiating this class (since our maps are static) and thus we can simplify our API by just using get method.
- Also we can lazily instantiate our maps.
